### PR TITLE
Allow requests for one second on verify request. Usefull when hoursVa…

### DIFF
--- a/SubscriptionSSOPlugin.inc.php
+++ b/SubscriptionSSOPlugin.inc.php
@@ -91,7 +91,7 @@ class SubscriptionSSOPlugin extends GenericPlugin {
 		$result =& $args[4]; // Reference required
 		if ($result) return false; // If a subscription has already been established, respect that
 
-		$result = isset($_SESSION['subscriptionSSOTimestamp']) && $_SESSION['subscriptionSSOTimestamp'] + ($this->getSetting($journal->getId(), 'hoursValid') * 3600) > time();
+		$result = isset($_SESSION['subscriptionSSOTimestamp']) && $_SESSION['subscriptionSSOTimestamp'] + ($this->getSetting($journal->getId(), 'hoursValid') * 3600) + 1 >= time();
 		if (!$result) {
 			// If we're not subscribed, redirect.
 			$request->redirectUrl($this->getSetting($journal->getId(), 'redirectUrl') . '?redirectUrl=' . urlencode($request->getRequestUrl()));


### PR DESCRIPTION
Hi @asmecher, this is a first approach with a minimal change. 

I have added one fixed second because in other case some times it works and others it launch the redirect.

I'm not sure if the 1 fixed second should be a new parameter in the settings in order an administrator to be able to custom extra seconds for congested systems, but this would require new translations.

I worked in other other approach setting a new $_SESSION['subscriptionSSOVerified'] in the loadHandlerCallback to be evaluated in subscribedUserCallback but the redirectUrl was requested twice when downloading one pdf file.